### PR TITLE
Clarify max-rows display text

### DIFF
--- a/csv_to_elastic.py
+++ b/csv_to_elastic.py
@@ -73,10 +73,14 @@ import dateutil.parser
 
 def main(file_path, delimiter, max_rows, elastic_index, json_struct, datetime_field, elastic_type, elastic_address, id_column):
     endpoint = '/_bulk'
+    if max_rows is None:
+      max_rows_disp = "all"
+    else:
+      max_rows_disp = max_rows
 
     print("")
     print(" ----- CSV to ElasticSearch ----- ")
-    print("Importing %s rows into `%s` from '%s'" % (max_rows, elastic_index, file_path))
+    print("Importing %s rows into `%s` from '%s'" % (max_rows_disp, elastic_index, file_path))
     print("")
 
     count = 0


### PR DESCRIPTION
When max-rows is not specified, clarify in text displayed to use that 'all' rows are being read, vice the currently displayed 'None', which could lead to confusion.