### PR TITLE
Add 'T' to the datetime

### DIFF
--- a/csv_to_elastic.py
+++ b/csv_to_elastic.py
@@ -110,7 +110,7 @@ def main(file_path, delimiter, max_rows, elastic_index, json_struct, datetime_fi
                 for header in headers:
                     if header == datetime_field:
                         datetime_type = dateutil.parser.parse(row[pos])
-                        _data = _data.replace('"%' + header + '%"', '"{:%Y-%m-%d %H:%M}"'.format(datetime_type))
+                        _data = _data.replace('"%' + header + '%"', '"{:%Y-%m-%dT%H:%M}"'.format(datetime_type))
                     else:
                         try:
                             int(row[pos])


### PR DESCRIPTION
Adding a 'T' to the datetime makes it automatically typed as 'date' by the dynamic date parser
(see date_hour_minute pattern at https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats )